### PR TITLE
Correcting CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.mustafaqasim.com
+blog.mustafaqasim.com


### PR DESCRIPTION
To make it live point www.mustafaqasim.com  to mustafaqasim.github.io.  Or, simple changing this CNAME will work, as blog.mustafaqasim.com already pointed to mustafaqasim.github.io.

Accept this pull request to fix the issue.